### PR TITLE
chore: skip preview deployments in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,6 @@
       "path": "/api/cron/warm-cache",
       "schedule": "0 4 * * *"
     }
-  ]
+  ],
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi"
 }


### PR DESCRIPTION
## Summary
- Adds `ignoreCommand` to vercel.json that skips builds for non-production environments
- Preserves existing crons configuration
- Only production branch deployments will trigger builds; all preview deployments are skipped

## How it works
Vercel runs the `ignoreCommand` before each build. If it exits with code 0, the build is skipped. This command checks if `VERCEL_ENV` is not `production` and exits 0 (skip) for all non-production deployments.